### PR TITLE
Update the PDP subscription form

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -107,7 +107,7 @@ module SolidusSubscriptions
     state_machine :state, initial: :active do
       event :cancel do
         transition [:active, :pending_cancellation] => :canceled,
-                   if: ->(subscription) { subscription.can_be_canceled? }
+          if: ->(subscription) { subscription.can_be_canceled? }
 
         transition active: :pending_cancellation
       end
@@ -122,7 +122,7 @@ module SolidusSubscriptions
 
       event :deactivate do
         transition active: :inactive,
-                   if: ->(subscription) { subscription.can_be_deactivated? }
+          if: ->(subscription) { subscription.can_be_deactivated? }
       end
 
       event :activate do

--- a/app/views/spree/frontend/products/_subscription_line_item_fields.html.erb
+++ b/app/views/spree/frontend/products/_subscription_line_item_fields.html.erb
@@ -1,30 +1,32 @@
-<%= content_tag :h3, t('.subscription_fields') %>
-<%= fields_for :'subscription_line_item', SolidusSubscriptions::LineItem.new do |ff| %>
-  <div>
-    <%= ff.label :quantity, t('.quantity') %>
-    <%= ff.number_field :quantity %>
-    <%= ff.label :quantity, t('.quantity_suffix') %>
-  </div>
+<% if @product.subscribable || @product.variants.any?(&:subscribable)%>
+  <%= content_tag :h3, t('.subscription_fields') %>
+  <%= fields_for :'subscription_line_item', SolidusSubscriptions::LineItem.new do |ff| %>
+    <div>
+      <%= ff.label :interval_length, t('.interval_length') %>
+      <%= ff.number_field :interval_length, value: 1 %>
 
-  <div>
-    <%= ff.label :interval_length, t('.interval_length') %>
-    <%= ff.number_field :interval_length %>
+      <%= ff.collection_radio_buttons :interval_units, SolidusSubscriptions::LineItem.interval_units.to_a, :first, :first, { checked: SolidusSubscriptions::LineItem.interval_units.to_a.first } %>
+    </div>
 
-    <%= ff.collection_radio_buttons :interval_units, SolidusSubscriptions::LineItem.interval_units.to_a, :first, :first %>
-  </div>
+    <%= ff.hidden_field :quantity %>
+    <%= ff.hidden_field :subscribable_id %>
+  <% end %>
 
-  <%= ff.hidden_field :subscribable_id %>
-<% end %>
+  <script>
+    document.addEventListener("DOMContentLoaded", function(e) {
+      var cartForm = document.querySelector('#cart-form form');
 
-<script>
-  document.addEventListener("DOMContentLoaded", function(e) {
-    var cartForm = document.querySelector('#cart-form form');
-    cartForm.addEventListener('submit', function(e) {
-      var quantityInput = e.target.querySelector('[name*="quantity"]');
-      var subscriptionQuantityInput = e.target.querySelector('[name*="subscribable_id"]');
+      cartForm.addEventListener('submit', function(e) {
+        var solidusQuantityInput = e.target.querySelector('[name*="quantity"]');
+        var quantityInput = e.target.querySelector('[name*="subscription_line_item[quantity]"]');
+        var variantInput = e.target.querySelector('[name*="variant_id"]');
+        var subscribableInput = e.target.querySelector('[name*="subscribable_id"]');
 
-      subscriptionQuantityInput.value = quantityInput.value;
-      return true;
+        quantityInput.value = solidusQuantityInput.value;
+        subscribableInput.value = variantInput.value;
+
+        return true;
+      });
     });
-  });
-</script>
+  </script>
+<% end %>


### PR DESCRIPTION
Ref: #243

Fix the subscription PDP additional fields removing some strange behaviur. Show the form only if the product or the one of the product variants are subscribable.
Use the PDP quantity field to set the subscription quantity.
Add default values for the interval units fields.
Set the selected variant for the subscribable id.

Result: 

![Screen Shot 2021-10-28 at 09 42 18 AM](https://user-images.githubusercontent.com/9986708/139211387-56a3d083-7a5c-4feb-be12-bf8b0147ece2.png)


