### PR TITLE
Fix filtering by line item in admin

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -84,12 +84,12 @@ module SolidusSubscriptions
     end)
 
     # Scope for finding subscription with a specific item
-    scope :with_line_item, (lambda do |id|
-      joins(:line_items).where(line_items: { id: id })
+    scope :with_subscribable, (lambda do |id|
+      joins(line_items: :subscribable).where(spree_variants: { id: id })
     end)
 
     def self.ransackable_scopes(_auth_object = nil)
-      [:in_processing_state, :with_line_item]
+      [:in_processing_state, :with_subscribable]
     end
 
     def self.processing_states

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -87,12 +87,12 @@
         </div>
         <div class="field-block col-3">
           <div class="field">
-            <%= label_tag :q_with_line_item_eq, SolidusSubscriptions::Subscription.human_attribute_name(:with_line_item) %>
+            <%= label_tag :q_with_subscribable_eq, SolidusSubscriptions::Subscription.human_attribute_name(:with_subscribable) %>
 
             <%=
               f.select(
-                :with_line_item,
-                options_for_select(::SolidusSubscriptions::LineItem.joins(:subscribable).map { |item| [ item.subscribable.name, item.id ]}, params.dig(:q, :with_line_item)),
+                :with_subscribable,
+                options_for_select(::Spree::Variant.includes(:product).where(id: ::SolidusSubscriptions::LineItem.distinct.pluck(:subscribable_id)).map { |subscribable| [ subscribable.name, subscribable.id ]}, params.dig(:q, :with_subscribable)),
                 { include_blank: true },
                 class: 'select2 fullwidth'
               )

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -137,7 +137,7 @@
           <td><%= subscription.interval.inspect %></td>
           <td><%= render 'state_pill', subscription: subscription %></td>
           <td><%= render 'processing_state_pill', subscription: subscription %></td>
-          <td><%= subscription.line_items.map { |line_item| line_item.subscribable&.name }.join(", ") %></td>
+          <td><%= subscription.line_items.includes(subscribable: :product).map { |line_item| line_item.subscribable&.name }.join(", ") %></td>
           <td class="actions">
             <% if subscription.state_events.include?(:cancel) %>
               <%=

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -1262,19 +1262,23 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   describe '.ransackable_scopes' do
     subject { described_class.ransackable_scopes }
 
-    it { is_expected.to match_array [:in_processing_state, :with_line_item] }
+    it { is_expected.to match_array [:in_processing_state, :with_subscribable] }
   end
 
-  describe '.with_line_item' do
+  describe '.with_subscribable' do
     let(:subscription) do
       create :subscription, :with_line_item
     end
+    let(:other_subscription) do
+      create :subscription, :with_line_item
+    end
 
-    it 'can find subscription with line item' do
-      line_item_id = subscription.line_items.first.id
-      found_subscription = ::SolidusSubscriptions::Subscription.with_line_item(line_item_id).first
+    it 'can find subscription with line items of the provided subscribable' do
+      subscribable = subscription.line_items.first.subscribable
+      other_subscribable = other_subscription.line_items.first.subscribable
 
-      expect(found_subscription.id).to eql(subscription.id)
+      expect(described_class.with_subscribable(subscribable)).to match_array([subscription])
+      expect(described_class.with_subscribable(other_subscribable)).to match_array([other_subscription])
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #274

This PR fixes the above issue by changing how the admin scopes subscriptions tied to a particular variant, instead of having to hunt down the specific line item when filtering them.

This also restructures the query in the view to avoid N+1s. On a store with 100K subscriptions the query and relative map take ~30ms.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
