### PR TITLE
Run specs on Ruby 2.7, 3.0 and 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,22 +8,48 @@ orbs:
   solidusio_extensions: solidusio/extensions@volatile
 
 jobs:
-  run-specs-with-postgres:
-    executor: solidusio_extensions/postgres
-    steps:
-      - checkout
-      - solidusio_extensions/run-tests-solidus-older
-      - solidusio_extensions/run-tests-solidus-current
-      - solidusio_extensions/run-tests-solidus-master
-      - solidusio_extensions/store-test-results
   run-specs-with-mysql:
-    executor: solidusio_extensions/mysql
+    executor:
+      name: solidusio_extensions/mysql
+      ruby_version: <<parameters.ruby_version>>
     steps:
       - checkout
       - solidusio_extensions/run-tests-solidus-older
       - solidusio_extensions/run-tests-solidus-current
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
+    parameters:
+      ruby_version:
+        type: string
+        default: '2.7'
+  run-specs-with-postgres:
+    executor:
+      name: solidusio_extensions/postgres
+      ruby_version: <<parameters.ruby_version>>
+    steps:
+      - checkout
+      - solidusio_extensions/run-tests-solidus-older
+      - solidusio_extensions/run-tests-solidus-current
+      - solidusio_extensions/run-tests-solidus-master
+      - solidusio_extensions/store-test-results
+    parameters:
+      ruby_version:
+        type: string
+        default: '3.0'
+  run-specs-with-sqlite:
+    executor:
+      name: solidusio_extensions/sqlite
+      ruby_version: <<parameters.ruby_version>>
+    steps:
+      - checkout
+      - solidusio_extensions/run-tests-solidus-older
+      - solidusio_extensions/run-tests-solidus-current
+      - solidusio_extensions/run-tests-solidus-master
+      - solidusio_extensions/store-test-results
+    parameters:
+      ruby_version:
+        type: string
+        default: '3.1'
   lint-code:
     executor: solidusio_extensions/sqlite-memory
     steps:
@@ -32,8 +58,15 @@ jobs:
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs-with-mysql:
+          ruby_version: '2.7'
+          name: run-specs-with-mysql-ruby-2.7
+      - run-specs-with-postgres:
+          ruby_version: '3.0'
+          name: run-specs-with-postgres-ruby-3.0
+      - run-specs-with-sqlite:
+          ruby_version: '3.1'
+          name: run-specs-with-sqlite-ruby-3.1
       - lint-code
 
   "Weekly run specs against master":
@@ -45,5 +78,12 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs-with-mysql:
+          ruby_version: '2.7'
+          name: run-specs-with-mysql-ruby-2.7
+      - run-specs-with-postgres:
+          ruby_version: '3.0'
+          name: run-specs-with-postgres-ruby-3.0
+      - run-specs-with-sqlite:
+          ruby_version: '3.1'
+          name: run-specs-with-sqlite-ruby-3.1


### PR DESCRIPTION
## Summary
ref #280 

Updates CircleCI config to run tests with Ruby 2.7, 3.0 and 3.1. It does not include all permutations of the DB options since they are pretty similar

📝 The specs are currently failing due to the issue with `solidus_frontend` not being compatible with `solidus` master (same failure on master)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] ~~I have added automated tests to cover my changes.~~
- [ ] ~~I have attached screenshots to demo visual changes.~~
- [ ] ~~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
- [ ] ~~I have updated the README to account for my changes.~~
