### PR TITLE
Allow updating subscription information in cart

### DIFF
--- a/lib/decorators/api/controllers/solidus_subscriptions/spree/api/line_items_controller/create_subscription_line_items.rb
+++ b/lib/decorators/api/controllers/solidus_subscriptions/spree/api/line_items_controller/create_subscription_line_items.rb
@@ -27,6 +27,20 @@ module SolidusSubscriptions
           def handle_subscription_line_items
             create_subscription_line_item(@line_item)
           end
+
+          def line_items_attributes
+            super.tap do |attrs|
+              if params[:subscription_line_items_attributes]
+                attrs[:line_items_attributes].merge!(
+                  subscription_line_items_attributes: subscription_line_item_params
+                )
+              end
+            end
+          end
+
+          def subscription_line_item_params
+            params[:subscription_line_items_attributes].permit(SolidusSubscriptions::PermittedAttributes.subscription_line_item_attributes)
+          end
         end
       end
     end

--- a/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -65,39 +65,41 @@ RSpec.describe Spree::Api::LineItemsController, type: :controller do
   end
 
   describe 'patch :update' do
-    subject(:patch_create) { patch :create, params: params }
+    subject(:patch_update) { patch :update, params: params }
 
     let(:params) { line_item_params }
-    let!(:variant) { create :variant }
-    let!(:order) { create :order }
-    let!(:line_item) { create :line_item, order: order, variant: variant }
 
-    let(:line_item_params) do
-      {
-        id: line_item.id,
-        order_id: order.number,
-        order_token: order.guest_token,
-        format: 'json',
-        line_item: {
-          quantity: 1,
-          variant_id: variant.id
-        },
-        subscription_line_item: {
-          quantity: 2,
-          end_date: '1990/10/12',
-          subscribable_id: variant.id,
-          interval_length: 30,
-          interval_units: "day"
+    context 'when adding subscription information' do
+      let(:variant) { create :variant }
+      let(:order) { create :order }
+      let(:line_item) { create :line_item, order: order, variant: variant }
+      let(:line_item_params) do
+        {
+          id: line_item.id,
+          order_id: order.number,
+          order_token: order.guest_token,
+          format: 'json',
+          line_item: {
+            quantity: 1,
+            variant_id: variant.id
+          },
+          subscription_line_item: {
+            quantity: 2,
+            end_date: '1990/10/12',
+            subscribable_id: variant.id,
+            interval_length: 30,
+            interval_units: "day"
+          }
         }
-      }
-    end
+      end
 
-    it { is_expected.to be_successful }
+      it { is_expected.to be_successful }
 
-    it 'creates a new subscription line item' do
-      expect { patch_create }.
-        to change(SolidusSubscriptions::LineItem, :count).
-        from(0).to(1)
+      it 'creates a new subscription line item' do
+        expect { patch_update }.
+          to change(SolidusSubscriptions::LineItem, :count).
+          from(0).to(1)
+      end
     end
   end
 end

--- a/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -101,5 +101,38 @@ RSpec.describe Spree::Api::LineItemsController, type: :controller do
           from(0).to(1)
       end
     end
+
+    context 'when updating subscription information' do
+      let!(:line_item) { create :subscription_line_item, interval_length: 30 }
+      let(:variant) { line_item.spree_line_item.variant }
+      let(:order) { line_item.spree_line_item.order }
+      let(:line_item_params) do
+        {
+          id: line_item.spree_line_item.id,
+          order_id: order.number,
+          order_token: order.guest_token,
+          format: 'json',
+          line_item: {
+            quantity: 1,
+          },
+          subscription_line_items_attributes: {
+            id: line_item.id,
+            interval_length: 15,
+          }
+        }
+      end
+
+      it { is_expected.to be_successful }
+
+      it 'does not create a new subscription line item' do
+        expect { patch_update }.
+          not_to change(SolidusSubscriptions::LineItem, :count)
+      end
+
+      it 'updates a new subscription line item' do
+        expect { patch_update }.
+          to change { line_item.reload.interval_length }.from(30).to(15)
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #279 

## Summary

`Spree::LineItem` already has defined in its model `accepts_nested_attributes_for :subscription_line_items` so we can leverage this to update a nested model of the line item.

The API call should be:

```
# https://example.com/api/orders/{order_number}/line_items/{line_item_id}

{
  "line_item": {
    "quantity": 1
  }
  "subscription_line_items_attributes": {
    "id": {subscription_line_item_id}
    "interval_length": 15,
  }
}
```

This "strange" unnested format is required for the way we are updating line items in the API line_item controller: https://github.com/solidusio/solidus/blob/e878076f2ed670d07654ab6293a16588743f2fa6/api/app/controllers/spree/api/line_items_controller.rb#L29. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
