### PR TITLE
Update built in promotions #eligible? signature

### DIFF
--- a/app/models/solidus_subscriptions/promotion/rules/subscription_creation_order.rb
+++ b/app/models/solidus_subscriptions/promotion/rules/subscription_creation_order.rb
@@ -24,7 +24,7 @@ module SolidusSubscriptions
         #   to it.
         #
         # @return [Boolean]
-        def eligible?(order, **_options)
+        def eligible?(order, _options = {})
           order.subscription_line_items.any?
         end
 

--- a/app/models/solidus_subscriptions/promotion/rules/subscription_installment_order.rb
+++ b/app/models/solidus_subscriptions/promotion/rules/subscription_installment_order.rb
@@ -22,7 +22,7 @@ module SolidusSubscriptions
         #   to it.
         #
         # @return [Boolean]
-        def eligible?(order, **_options)
+        def eligible?(order, _options = {})
           order.subscription_order?
         end
       end


### PR DESCRIPTION
## Summary

While working on a client project and upgrading to Ruby 3, the mismatch in how the #eligible? is signed between solidus_core and solidus_subscriptions made some code break because Spree::Promotion#eligible_rules? doesn't double splat the options.

Before Ruby 3 the double splat would return a Hash, however with Ruby 3 those are kept as keyword arguments, breaking the method call site.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
