### PR TITLE
Only use the newer Solidus event system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,66 +8,45 @@ orbs:
   solidusio_extensions: solidusio/extensions@volatile
 
 jobs:
-  run-specs-with-mysql:
+  run-specs:
+    parameters:
+      solidus:
+        type: string
+        default: master
+      db:
+        type: string
+        default: "postgres"
+      ruby:
+        type: string
+        default: "3.2"
     executor:
-      name: solidusio_extensions/mysql
-      ruby_version: <<parameters.ruby_version>>
+      name: solidusio_extensions/<< parameters.db >>
+      ruby_version: << parameters.ruby >>
     steps:
       - checkout
-      - solidusio_extensions/run-tests-solidus-older
-      - solidusio_extensions/run-tests-solidus-current
-      - solidusio_extensions/run-tests-solidus-master
-      - solidusio_extensions/store-test-results
-    parameters:
-      ruby_version:
-        type: string
-        default: '2.7'
-  run-specs-with-postgres:
-    executor:
-      name: solidusio_extensions/postgres
-      ruby_version: <<parameters.ruby_version>>
-    steps:
-      - checkout
-      - solidusio_extensions/run-tests-solidus-older
-      - solidusio_extensions/run-tests-solidus-current
-      - solidusio_extensions/run-tests-solidus-master
-      - solidusio_extensions/store-test-results
-    parameters:
-      ruby_version:
-        type: string
-        default: '3.0'
-  run-specs-with-sqlite:
-    executor:
-      name: solidusio_extensions/sqlite
-      ruby_version: <<parameters.ruby_version>>
-    steps:
-      - checkout
-      - solidusio_extensions/run-tests-solidus-older
-      - solidusio_extensions/run-tests-solidus-current
-      - solidusio_extensions/run-tests-solidus-master
-      - solidusio_extensions/store-test-results
-    parameters:
-      ruby_version:
-        type: string
-        default: '3.1'
+      - solidusio_extensions/run-tests-solidus-<< parameters.solidus >>
   lint-code:
-    executor: solidusio_extensions/sqlite-memory
+    executor:
+      name: solidusio_extensions/sqlite-memory
+      ruby_version: 2.5
     steps:
       - solidusio_extensions/lint-code
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-mysql:
-          ruby_version: '2.7'
-          name: run-specs-with-mysql-ruby-2.7
-      - run-specs-with-postgres:
-          ruby_version: '3.0'
-          name: run-specs-with-postgres-ruby-3.0
-      - run-specs-with-sqlite:
-          ruby_version: '3.1'
-          name: run-specs-with-sqlite-ruby-3.1
-      - lint-code
+      - run-specs:
+          name: &name "run-specs-solidus-<< matrix.solidus >>-ruby-<< matrix.ruby >>-db-<< matrix.db >>"
+          matrix:
+            parameters: { solidus: ["master"], ruby: ["3.2"], db: ["postgres"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["current"], ruby: ["3.1"], db: ["mysql"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["older"], ruby: ["3.0"], db: ["sqlite"] }
 
   "Weekly run specs against master":
     triggers:
@@ -78,12 +57,11 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-mysql:
-          ruby_version: '2.7'
-          name: run-specs-with-mysql-ruby-2.7
-      - run-specs-with-postgres:
-          ruby_version: '3.0'
-          name: run-specs-with-postgres-ruby-3.0
-      - run-specs-with-sqlite:
-          ruby_version: '3.1'
-          name: run-specs-with-sqlite-ruby-3.1
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["master"], ruby: ["3.2"], db: ["postgres"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["current"], ruby: ["3.1"], db: ["mysql"] }

--- a/app/subscribers/solidus_subscriptions/churn_buster_subscriber.rb
+++ b/app/subscribers/solidus_subscriptions/churn_buster_subscriber.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 module SolidusSubscriptions
-  module ChurnBusterSubscriber
-    include ::Spree::Event::Subscriber
-    include ::SolidusSupport::LegacyEventCompat::Subscriber
+  class ChurnBusterSubscriber
+    include Omnes::Subscriber
 
-    event_action :report_subscription_cancellation, event_name: 'solidus_subscriptions.subscription_canceled'
-    event_action :report_subscription_ending, event_name: 'solidus_subscriptions.subscription_ended'
-    event_action :report_payment_success, event_name: 'solidus_subscriptions.installment_succeeded'
-    event_action :report_payment_failure, event_name: 'solidus_subscriptions.installment_failed_payment'
-    event_action :report_payment_method_change, event_name: 'solidus_subscriptions.subscription_payment_method_changed'
+    handle :"solidus_subscriptions.subscription_canceled", with: :report_subscription_cancellation
+    handle :"solidus_subscriptions.subscription_ended", with: :report_subscription_ending
+    handle :"solidus_subscriptions.installment_succeeded", with: :report_payment_success
+    handle :"solidus_subscriptions.installment_failed_payment", with: :report_payment_failure
+    handle :"solidus_subscriptions.subscription_payment_method_changed", with: :report_payment_method_change
 
     def report_subscription_cancellation(event)
       churn_buster&.report_subscription_cancellation(event.payload.fetch(:subscription))

--- a/app/subscribers/solidus_subscriptions/event_storage_subscriber.rb
+++ b/app/subscribers/solidus_subscriptions/event_storage_subscriber.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 module SolidusSubscriptions
-  module EventStorageSubscriber
-    include ::Spree::Event::Subscriber
-    include ::SolidusSupport::LegacyEventCompat::Subscriber
+  class EventStorageSubscriber
+    include Omnes::Subscriber
 
-    event_action :track_subscription_created, event_name: 'solidus_subscriptions.subscription_created'
-    event_action :track_subscription_activated, event_name: 'solidus_subscriptions.subscription_activated'
-    event_action :track_subscription_canceled, event_name: 'solidus_subscriptions.subscription_canceled'
-    event_action :track_subscription_ended, event_name: 'solidus_subscriptions.subscription_ended'
-    event_action :track_subscription_shipping_address_changed, event_name: 'solidus_subscriptions.subscription_shipping_address_changed'
-    event_action :track_subscription_billing_address_changed, event_name: 'solidus_subscriptions.subscription_billing_address_changed'
-    event_action :track_subscription_frequency_changed, event_name: 'solidus_subscriptions.subscription_frequency_changed'
+    handle :"solidus_subscriptions.subscription_created", with: :track_subscription_created
+    handle :"solidus_subscriptions.subscription_activated", with: :track_subscription_activated
+    handle :"solidus_subscriptions.subscription_canceled", with: :track_subscription_canceled
+    handle :"solidus_subscriptions.subscription_ended", with: :track_subscription_ended
+    handle :"solidus_subscriptions.subscription_shipping_address_changed", with: :track_subscription_shipping_address_changed
+    handle :"solidus_subscriptions.subscription_billing_address_changed", with: :track_subscription_billing_address_changed
+    handle :"solidus_subscriptions.subscription_frequency_changed", with: :track_subscription_frequency_changed
 
     def track_subscription_created(event)
       event.payload.fetch(:subscription).events.create!(

--- a/app/subscribers/solidus_subscriptions/order_subscriber.rb
+++ b/app/subscribers/solidus_subscriptions/order_subscriber.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 module SolidusSubscriptions
-  module OrderSubscriber
-    include ::Spree::Event::Subscriber
-    include ::SolidusSupport::LegacyEventCompat::Subscriber
+  class OrderSubscriber
+    include Omnes::Subscriber
 
-    event_action :create_subscription, event_name: 'order_finalized'
-
-    private
+    handle :order_finalized, with: :create_subscription
 
     def create_subscription(event)
       SolidusSubscriptions::CreateSubscriptionJob.perform_later(event.payload[:order])

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -51,29 +51,27 @@ module SolidusSubscriptions
     end
 
     initializer 'solidus_subscriptions.pub_sub' do |app|
-      unless SolidusSupport::LegacyEventCompat.using_legacy?
-        app.reloader.to_prepare do
-          %i[
-            subscription_created
-            subscription_activated
-            subscription_canceled
-            subscription_ended
-            subscription_skipped
-            subscription_resumed
-            subscription_paused
-            subscription_frequency_changed
-            subscription_shipping_address_changed
-            subscription_billing_address_changed
-            installment_succeeded
-            installment_failed_payment
-            subscription_payment_method_changed
-          ].each do |event_name|
-            ::Spree::Bus.register(:"solidus_subscriptions.#{event_name}")
-          end
-          SolidusSubscriptions::ChurnBusterSubscriber.omnes_subscriber.subscribe_to(::Spree::Bus)
-          SolidusSubscriptions::EventStorageSubscriber.omnes_subscriber.subscribe_to(::Spree::Bus)
-          SolidusSubscriptions::OrderSubscriber.omnes_subscriber.subscribe_to(::Spree::Bus)
+      app.reloader.to_prepare do
+        %i[
+          subscription_created
+          subscription_activated
+          subscription_canceled
+          subscription_ended
+          subscription_skipped
+          subscription_resumed
+          subscription_paused
+          subscription_frequency_changed
+          subscription_shipping_address_changed
+          subscription_billing_address_changed
+          installment_succeeded
+          installment_failed_payment
+          subscription_payment_method_changed
+        ].each do |event_name|
+          ::Spree::Bus.register(:"solidus_subscriptions.#{event_name}")
         end
+        SolidusSubscriptions::ChurnBusterSubscriber.new.subscribe_to(::Spree::Bus)
+        SolidusSubscriptions::EventStorageSubscriber.new.subscribe_to(::Spree::Bus)
+        SolidusSubscriptions::OrderSubscriber.new.subscribe_to(::Spree::Bus)
       end
     end
   end


### PR DESCRIPTION
## Summary

The old one has been removed on v4.0.

We'll need a major release after this change is merged.

See https://github.com/solidusio/solidus/pull/5024

We're also fixing CI with different changes to our CircleCI config:

- Run different Solidus versions on different jobs for better error handling.
- We're now explicitly providing the ruby version to the executor while using a matrix configuration for better extensibility.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
