### PR TITLE
Don't allocate an empty hash for each call to #eligible?

### DIFF
--- a/app/models/solidus_subscriptions/promotion/rules/subscription_creation_order.rb
+++ b/app/models/solidus_subscriptions/promotion/rules/subscription_creation_order.rb
@@ -24,7 +24,7 @@ module SolidusSubscriptions
         #   to it.
         #
         # @return [Boolean]
-        def eligible?(order, _options = {})
+        def eligible?(order, _options = nil)
           order.subscription_line_items.any?
         end
 

--- a/app/models/solidus_subscriptions/promotion/rules/subscription_installment_order.rb
+++ b/app/models/solidus_subscriptions/promotion/rules/subscription_installment_order.rb
@@ -22,7 +22,7 @@ module SolidusSubscriptions
         #   to it.
         #
         # @return [Boolean]
-        def eligible?(order, _options = {})
+        def eligible?(order, _options = nil)
           order.subscription_order?
         end
       end


### PR DESCRIPTION
## Summary


~~This error was reported:~~

```
ArgumentError (wrong number of arguments (given 2, expected 1)):
solidus_subscriptions (5b4c7052ace3) app/models/solidus_subscriptions/promotion/rules/subscription_creation_order.rb:27:in `eligible?'
```

~~And it looks like solidus is not using keyword arguments inside `#eligible?` so we'll stop doing it here as well, probably wasn't a problem until the ruby version was bumped.~~

_Fixed by #283_

Also set the default value to `nil` so no additional hashes are allocated.


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
