### PR TITLE
Change default frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,27 @@ Add solidus_subscriptions to your Gemfile:
 gem 'solidus_subscriptions', github: 'solidusio/solidus_subscriptions'
 ```
 
+### Starter Frontend
+
 Bundle your dependencies and run the installation generator:
 
 ```shell
 $ bundle
-$ bin/rails generate solidus_subscriptions:install --frontend=starter
+$ bin/rails generate solidus_subscriptions:install
 ```
 
-Please, be aware that the starter installation only works with the default
+Please, be aware that the installation only works with the default
 implementation of the starter frontend. Any customization to the files that
 will be modified by the installer might break the installation procedure.
 If that happens, try to adapt the installed code on top of the customizations
 of the store.
 
+### Legacy Frontend
 
 If you are using the legacy `solidus_frontend` gem, please run this command instead:
 
 ```shell
-$ bin/rails generate solidus_subscriptions:install
+$ bin/rails generate solidus_subscriptions:install --frontend=classic
 ```
 
 ### Guest checkout

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -71,7 +71,7 @@ unbundled bundle exec rails generate solidus:install \
   --payment-method=none \
   $@
 
-unbundled bundle exec rails generate ${extension_name}:install --frontend=starter --auto-run-migrations=true
+unbundled bundle exec rails generate ${extension_name}:install --auto-run-migrations=true
 
 echo
 echo "🚀 Sandbox app successfully created for $extension_name!"

--- a/lib/generators/solidus_subscriptions/install/install_generator.rb
+++ b/lib/generators/solidus_subscriptions/install/install_generator.rb
@@ -6,7 +6,8 @@ module SolidusSubscriptions
       source_root File.expand_path('templates', __dir__)
 
       class_option :auto_run_migrations, type: :boolean, default: false
-      class_option :frontend, type: :string, default: 'classic'
+      # Either 'starter' or 'classic'
+      class_option :frontend, type: :string, default: 'starter'
 
       def copy_initializer
         template 'initializer.rb', 'config/initializers/solidus_subscriptions.rb'


### PR DESCRIPTION
## Summary

Now that we have committed to the Starter StoreFront as the default, it may be confusing to see that this extension installs on the legacy one by default.
I have made some small changes to make the SSF the default. To install on the legacy Frontend, it must be specified explicitly.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

[x] 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
