### PR TITLE
Update out_of_stock_dispatcher_class in attr_writer

### DIFF
--- a/lib/generators/solidus_subscriptions/install/templates/initializer.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/initializer.rb
@@ -50,7 +50,7 @@ SolidusSubscriptions.configure do |config|
   # config.payment_failed_dispatcher_class = 'SolidusSubscriptions::Dispatcher::PaymentFailedDispatcher'
 
   # This handler is called when there isn't enough stock to fulfill an installment.
-  # config.out_of_stock_dispatcher = 'SolidusSubscriptions::Dispatcher::OutOfStockDispatcher'
+  # config.out_of_stock_dispatcher_class = 'SolidusSubscriptions::Dispatcher::OutOfStockDispatcher'
 
   # ===================================== Permitted attributes =====================================
   #

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -15,7 +15,7 @@ module SolidusSubscriptions
       :maximum_successive_skips,
       :minimum_cancellation_notice,
       :order_creator_class,
-      :out_of_stock_dispatcher,
+      :out_of_stock_dispatcher_class,
       :payment_failed_dispatcher_class,
       :processing_error_handler,
       :processing_queue,


### PR DESCRIPTION
## Summary

I noticed my subscription out of stock events weren't firing correctly on an application I was working on because the `attr_writer` in the `solidus_subscription` gem wasn't updated with the correct method name which is supposed to be `out_of_stock_dispatcher_class` instead of `out_of_stock_dispatcher`. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
