### PR TITLE
allow use without solidus_backend

### DIFF
--- a/app/overrides/views/admin_subscriptions_menu_link.rb
+++ b/app/overrides/views/admin_subscriptions_menu_link.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if !Spree::Backend::Config.respond_to?(:menu_items)
+if SolidusSupport.backend_available? && !Spree::Backend::Config.respond_to?(:menu_items)
   Deface::Override.new(
     virtual_path: 'spree/admin/shared/_menu',
     name: :add_subcriptions_admin_link,

--- a/lib/generators/solidus_subscriptions/install/install_generator.rb
+++ b/lib/generators/solidus_subscriptions/install/install_generator.rb
@@ -14,7 +14,9 @@ module SolidusSubscriptions
       end
 
       def add_javascripts
-        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_subscriptions\n"
+        if SolidusSupport.backend_available?
+          append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_subscriptions\n"
+        end
       end
 
       def copy_starter_frontend_files

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -37,7 +37,7 @@ module SolidusSubscriptions
     end
 
     initializer 'solidus_subscriptions.configure_backend' do
-      next unless ::Spree::Backend::Config.respond_to?(:menu_items)
+      next unless SolidusSupport.backend_available? && ::Spree::Backend::Config.respond_to?(:menu_items)
 
       ::Spree::Backend::Config.configure do |config|
         config.menu_items << config.class::MenuItem.new(


### PR DESCRIPTION
## Summary
Currently `solidus_subscriptions` has references to `solidus_backend`, even when `solidus_backend` isn't a dependency on gemspec.

It will be easier just add `solidus_backend` as dependency in gemspec, but I think the plan with `solidus_admin` is to eventually replace `solidus_backend`. So, this PR allows use `solidus_subscriptions` extension without `solidus_backend`.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
