### PR TITLE
Ransack searchable attribute issue in admin

### DIFF
--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -133,7 +133,7 @@ module SolidusSubscriptions
     end
 
     def self.ransackable_attributes(_auth_object = nil)
-      %w[actionable_date created_at id id_value subscription_id updated_at]
+      %w[actionable_date created_at updated_at]
     end
   end
 end

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -131,5 +131,9 @@ module SolidusSubscriptions
 
       (DateTime.current + SolidusSubscriptions.configuration.reprocessing_interval).beginning_of_minute
     end
+
+    def self.ransackable_attributes(_auth_object = nil)
+      %w[actionable_date created_at id id_value subscription_id updated_at]
+    end
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -432,5 +432,14 @@ module SolidusSubscriptions
         emit_event(type: 'subscription_payment_method_changed')
       end
     end
+
+    def self.ransackable_attributes(_auth_object = nil)
+      %w[actionable_date billing_address_id created_at currency end_date guest_token id id_value interval_length interval_units paused payment_method_id payment_source_id payment_source_type shipping_address_id skip_count state store_id successive_skip_count updated_at user_id]
+    end
+
+    def self.ransackable_associations(_auth_object = nil)
+      %w[billing_address events installment_details installments line_items orders payment_method payment_source shipping_address store user]
+    end
+
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -434,11 +434,11 @@ module SolidusSubscriptions
     end
 
     def self.ransackable_attributes(_auth_object = nil)
-      %w[actionable_date billing_address_id created_at currency end_date guest_token id id_value interval_length interval_units paused payment_method_id payment_source_id payment_source_type shipping_address_id skip_count state store_id successive_skip_count updated_at user_id]
+      %w[actionable_date created_at end_date state  updated_at user_id]
     end
 
     def self.ransackable_associations(_auth_object = nil)
-      %w[billing_address events installment_details installments line_items orders payment_method payment_source shipping_address store user]
+      %w[events user]
     end
 
   end

--- a/app/models/solidus_subscriptions/subscription_event.rb
+++ b/app/models/solidus_subscriptions/subscription_event.rb
@@ -9,7 +9,7 @@ module SolidusSubscriptions
     end
 
     def self.ransackable_attributes(_auth_object = nil)
-      %w[created_at details event_type id id_value subscription_id updated_at]
+      %w[created_at subscription_id updated_at]
     end
   end
 end

--- a/app/models/solidus_subscriptions/subscription_event.rb
+++ b/app/models/solidus_subscriptions/subscription_event.rb
@@ -7,5 +7,9 @@ module SolidusSubscriptions
     after_initialize do
       self.details ||= {}
     end
+
+    def self.ransackable_attributes(_auth_object = nil)
+      %w[created_at details event_type id id_value subscription_id updated_at]
+    end
   end
 end


### PR DESCRIPTION
## Summary

  
  Issue - Runtime Error in Spree::Admin::Subscriptions. Ransack needs Solidus Subscriptions, Installments, Events attributes explicitly allowlisted as searchable 

![Screenshot 2024-06-17 175900](https://github.com/solidusio/solidus_subscriptions/assets/50630054/1aa3c10c-2272-4920-b00a-d528bd8a490a)

 Fixes - Added the methods to make subscriptions, installments, events attributes allowlisted as searchable.

## Checklist

- I have written a thorough PR description.
- I have kept my commits small and atomic.
- I have used clear, explanatory commit messages
- 📸 I have attached screenshots to demo visual changes.
