### PR TITLE
Run legacy promotion handler "cart" if legacy promo system present

### DIFF
--- a/lib/solidus_subscriptions/checkout.rb
+++ b/lib/solidus_subscriptions/checkout.rb
@@ -42,6 +42,9 @@ module SolidusSubscriptions
     end
 
     def finalize_order(order)
+      # Rerun the legacy promotion handler
+      # `solidus_promotions` does not need this handler, and will pickup promotions in `order.recalculate`
+      ::Spree::PromotionHandler::Cart.new(order).activate if defined?(::Spree::PromotionHandler::Cart)
       order.recalculate
 
       order.checkout_steps[0...-1].each do

--- a/lib/solidus_subscriptions/subscription_line_item_builder.rb
+++ b/lib/solidus_subscriptions/subscription_line_item_builder.rb
@@ -9,6 +9,9 @@ module SolidusSubscriptions
         subscription_params.merge(spree_line_item: line_item)
       )
 
+      # Rerun the legacy promotion handler to pickup subscription promotions
+      # `solidus_promotions` does not need this handler, and will pickup promotions in `order.recalculate`
+      ::Spree::PromotionHandler::Cart.new(line_item.order).activate if defined?(::Spree::PromotionHandler::Cart)
       line_item.order.recalculate
     end
 


### PR DESCRIPTION
In the legacy promotion system, there's a separation of tasks between `order.recalculate` and `PromotionHandler::Cart`. `order.recalculate` will only recalculate already existing promotion adjustments, but will not check for any new promotions that might need to be applied. In the new promotion system, both of these tasks are handled by `order.recalculate`.

If the legacy promotion system is present, but not active, calling this promotion handler will result in a single database call, which is an acceptable price to pay I think.

