### PR TITLE
Subscription api fix for subscribable product

### DIFF
--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -38,5 +38,12 @@ module SolidusSubscriptions
     validates :subscribable_id, presence: true
     validates :quantity, numericality: { greater_than: 0 }
     validates :interval_length, numericality: { greater_than: 0 }, unless: -> { subscription }
+    validate :ensure_subscribable_is_true
+
+    def ensure_subscribable_is_true
+      return unless subscribable && subscribable.subscribable != true
+
+      errors.add(:subscribable, :cannot_subscribe)
+    end
   end
 end

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -38,9 +38,9 @@ module SolidusSubscriptions
     validates :subscribable_id, presence: true
     validates :quantity, numericality: { greater_than: 0 }
     validates :interval_length, numericality: { greater_than: 0 }, unless: -> { subscription }
-    validate :ensure_subscribable_is_true
+    validate :ensure_subscribable_valid
 
-    def ensure_subscribable_is_true
+    def ensure_subscribable_valid
       return unless subscribable && subscribable.subscribable != true
 
       errors.add(:subscribable, :cannot_subscribe)

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -434,12 +434,11 @@ module SolidusSubscriptions
     end
 
     def self.ransackable_attributes(_auth_object = nil)
-      %w[actionable_date created_at end_date state  updated_at user_id]
+      %w[actionable_date created_at end_date state updated_at user_id]
     end
 
     def self.ransackable_associations(_auth_object = nil)
       %w[events user]
     end
-
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,3 +136,7 @@ en:
               not_active: "cannot pause/resume a subscription which is not active"
             state:
               cannot_skip: cannot skip a subscription which is canceled or inactive
+        solidus_subscriptions/line_item:
+          attributes:
+            subscribable:
+              cannot_subscribe: "The requested item cannot be subscribed"

--- a/db/migrate/20210323165714_update_promotion_rule_names.rb
+++ b/db/migrate/20210323165714_update_promotion_rule_names.rb
@@ -5,6 +5,8 @@ class UpdatePromotionRuleNames < ActiveRecord::Migration[5.2]
   }.freeze
 
   def change
+    return unless Object.const_defined?("Spree::Promotion")
+
     reversible do |dir|
       dir.up do
         TYPE_RENAMES.each do |old_type, new_type|

--- a/lib/generators/solidus_subscriptions/install/install_generator.rb
+++ b/lib/generators/solidus_subscriptions/install/install_generator.rb
@@ -30,6 +30,10 @@ module SolidusSubscriptions
 
           RUBY
         end
+
+        inject_into_file 'app/views/cart_line_items/_product_variants.html.erb',
+          "            \"data-subscribable\" => variant.subscribable,\n",
+          before: "            \"data-price\" => variant.price_for_options(current_pricing_options)&.money&.to_html\n"
       end
 
       def add_migrations

--- a/lib/generators/solidus_subscriptions/install/templates/app/controllers/concerns/create_subscription.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/app/controllers/concerns/create_subscription.rb
@@ -5,7 +5,7 @@ module CreateSubscription
   include SolidusSubscriptions::SubscriptionLineItemBuilder
 
   included do
-    after_action :handle_subscription_line_items, only: :create, if: :subscription_line_item_params_present?
+    after_action :handle_subscription_line_items, only: :create, if: :valid_subscription_line_item_params?
   end
 
   private
@@ -15,13 +15,8 @@ module CreateSubscription
     create_subscription_line_item(line_item)
   end
 
-  def subscription_params
-    params.fetch(:subscription_line_item, {})
-  end
-
-  def subscription_line_item_params_present?
-    subscription_params[:subscribable_id].present? &&
-      subscription_params[:quantity].present? &&
-      subscription_params[:interval_length].present?
+  def valid_subscription_line_item_params?
+    subscription_params = params[:subscription_line_item]
+    %i[subscribable_id quantity interval_length].all? { |key| subscription_params[key].present? }
   end
 end

--- a/lib/generators/solidus_subscriptions/install/templates/app/controllers/concerns/create_subscription.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/app/controllers/concerns/create_subscription.rb
@@ -5,7 +5,7 @@ module CreateSubscription
   include SolidusSubscriptions::SubscriptionLineItemBuilder
 
   included do
-    after_action :handle_subscription_line_items, only: :create, if: ->{ params[:subscription_line_item] }
+    after_action :handle_subscription_line_items, only: :create, if: :subscription_line_item_params_present?
   end
 
   private
@@ -13,5 +13,15 @@ module CreateSubscription
   def handle_subscription_line_items
     line_item = @current_order.line_items.find_by(variant_id: params[:variant_id])
     create_subscription_line_item(line_item)
+  end
+
+  def subscription_params
+    params.fetch(:subscription_line_item, {})
+  end
+
+  def subscription_line_item_params_present?
+    subscription_params[:subscribable_id].present? &&
+      subscription_params[:quantity].present? &&
+      subscription_params[:interval_length].present?
   end
 end

--- a/lib/generators/solidus_subscriptions/install/templates/app/views/cart_line_items/_subscription_fields.html.erb
+++ b/lib/generators/solidus_subscriptions/install/templates/app/views/cart_line_items/_subscription_fields.html.erb
@@ -1,39 +1,52 @@
-<% if @product.subscribable %>
-  <%= content_tag :h3, t('.subscription_fields') %>
-  <%= fields_for :'subscription_line_item', SolidusSubscriptions::LineItem.new do |ff| %>
-    <div>
-      <%= ff.label :quantity, t('.quantity') %>
-      <%= ff.number_field :quantity %>
-      <%= ff.label :quantity, t('.quantity_suffix') %>
-    </div>
+<div class="subscription-form">
+  <% if @product.subscribable %>
+    <%= content_tag :h3, t('.subscription_fields') %>
+    <%= fields_for :'subscription_line_item', SolidusSubscriptions::LineItem.new do |ff| %>
+      <div>
+        <%= ff.label :quantity, t('.quantity') %>
+        <%= ff.number_field :quantity %>
+        <%= ff.label :quantity, t('.quantity_suffix') %>
+      </div>
 
-    <div>
-      <%= ff.label :interval_length, t('.interval_length') %>
-      <%= ff.number_field :interval_length %>
+      <div>
+        <%= ff.label :interval_length, t('.interval_length') %>
+        <%= ff.number_field :interval_length %>
 
-      <%= ff.collection_radio_buttons :interval_units, SolidusSubscriptions::LineItem.interval_units.to_a, :first, :first %>
-    </div>
+        <%= ff.collection_radio_buttons :interval_units, SolidusSubscriptions::LineItem.interval_units.to_a, :first, :first %>
+      </div>
 
-    <%= ff.hidden_field :subscribable_id %>
+      <%= ff.hidden_field :subscribable_id %> <!-- Hidden field for subscribable_id -->
+    <% end %>
   <% end %>
-<% end %>
+</div>
 
 <script>
-  document.addEventListener("DOMContentLoaded", function(e) {
+  document.addEventListener("DOMContentLoaded", function() {
     var cartForm = document.querySelector('form[action="/cart_line_items"]');
+    var variantRadioButtons = cartForm.querySelectorAll('[data-js="variant-radio"]');
+    var subscribableInput = cartForm.querySelector('[name*="subscription_line_item[subscribable_id]"]');
+    var subscriptionFields = document.querySelector('.subscription-form'); // Select the subscription form container
 
-    cartForm.addEventListener('submit', function(e) {
-      var variantInput = e.target.querySelector('[name*="variant_id"]:checked');
-      var subscribableInput = e.target.querySelector('[name*="subscription_line_item[subscribable_id]"]');
+    function handleVariantSelection(e) {
+      var variantRadioButton = e.target;
+      var isSubscribable = variantRadioButton.getAttribute('data-subscribable') === 'true';
 
-      if (!variantInput) {
-        variantInput = cartForm.querySelector('[name="variant_id"]');
+      if (isSubscribable) {
+        subscribableInput.value = variantRadioButton.value;
+        subscriptionFields.style.display = 'block';
+      } else {
+        subscriptionFields.style.display = 'none';
       }
+    }
 
-      subscribableInput.value = variantInput.value;
-
-      return true;
+    variantRadioButtons.forEach(function(variantRadioButton) {
+      variantRadioButton.addEventListener('change', handleVariantSelection);
     });
+
+    var selectedVariantRadioButton = cartForm.querySelector('[data-js="variant-radio"]:checked');
+    if (selectedVariantRadioButton) {
+      handleVariantSelection({ target: selectedVariantRadioButton });
+    }
   });
 </script>
 

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -31,9 +31,11 @@ module SolidusSubscriptions
       }
     end
 
-    initializer 'solidus_subscriptions.register_promotion_rules', after: 'spree.promo.register.promotion.rules' do |app|
-      app.config.spree.promotions.rules << 'SolidusSubscriptions::Promotion::Rules::SubscriptionCreationOrder'
-      app.config.spree.promotions.rules << 'SolidusSubscriptions::Promotion::Rules::SubscriptionInstallmentOrder'
+    if Object.const_defined?("Spree::Promotion")
+      initializer 'solidus_subscriptions.register_promotion_rules', after: 'spree.promo.register.promotion.rules' do |app|
+        app.config.spree.promotions.rules << 'SolidusSubscriptions::Promotion::Rules::SubscriptionCreationOrder'
+        app.config.spree.promotions.rules << 'SolidusSubscriptions::Promotion::Rules::SubscriptionInstallmentOrder'
+      end
     end
 
     initializer 'solidus_subscriptions.configure_backend' do

--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'httparty', '~> 0.18'
   spec.add_dependency 'i18n'
   spec.add_dependency 'solidus_core', '>= 2.11', '< 5'
-  spec.add_dependency 'solidus_support', '~> 0.9'
+  spec.add_dependency 'solidus_support', '~> 0.11'
   spec.add_dependency 'state_machines'
 
   spec.add_development_dependency 'rspec-activemodel-mocks'

--- a/spec/controllers/concerns/create_subscription_spec.rb
+++ b/spec/controllers/concerns/create_subscription_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CreateSubscription, type: :controller do
   describe '#handle_subscription_line_items' do
     context 'when subscription params are missing' do
       it 'does not invoke handle_subscription_line_items and does not create a subscription line item' do
-        initial_line_item_count = order.line_items.count
+        order.line_items.count
 
         controller_instance.params = {
           variant_id: variant.id,

--- a/spec/controllers/concerns/create_subscription_spec.rb
+++ b/spec/controllers/concerns/create_subscription_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CreateSubscription, type: :controller do
             interval_length: 1
           }
         }
-        expect(controller_instance.send(:subscription_line_item_params_present?)).to be true
+        expect(controller_instance.send(:valid_subscription_line_item_params?)).to be true
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe CreateSubscription, type: :controller do
             interval_length: ''
           }
         }
-        expect(controller_instance.send(:subscription_line_item_params_present?)).to be false
+        expect(controller_instance.send(:valid_subscription_line_item_params?)).to be false
       end
     end
   end
@@ -59,7 +59,7 @@ RSpec.describe CreateSubscription, type: :controller do
           subscription_line_item: {}
         }
 
-        expect(controller_instance.send(:subscription_line_item_params_present?)).to be false
+        expect(controller_instance.send(:valid_subscription_line_item_params?)).to be false
 
         expect(controller_instance).not_to receive(:handle_subscription_line_items)
 

--- a/spec/controllers/concerns/create_subscription_spec.rb
+++ b/spec/controllers/concerns/create_subscription_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require_relative '../../../lib/generators/solidus_subscriptions/install/templates/app/controllers/concerns/create_subscription'
+
+RSpec.describe CreateSubscription, type: :controller do
+  subject(:controller_instance) do
+    Class.new(ApplicationController) do
+      include CreateSubscription
+      attr_accessor :params, :current_order
+
+      def initialize(params = {})
+        @params = params
+        @current_order = nil
+      end
+    end.new
+  end
+
+  let(:variant) { create(:variant) }
+  let(:order) { create(:order) }
+
+  before do
+    controller_instance.current_order = order
+  end
+
+  describe '#subscription_line_item_params_present?' do
+    context 'when all required params are present' do
+      it 'returns true' do
+        controller_instance.params = {
+          subscription_line_item: {
+            subscribable_id: 1,
+            quantity: 2,
+            interval_length: 1
+          }
+        }
+        expect(controller_instance.send(:subscription_line_item_params_present?)).to be true
+      end
+    end
+
+    context 'when required params are missing' do
+      it 'returns false' do
+        controller_instance.params = {
+          subscription_line_item: {
+            subscribable_id: '',
+            quantity: '',
+            interval_length: ''
+          }
+        }
+        expect(controller_instance.send(:subscription_line_item_params_present?)).to be false
+      end
+    end
+  end
+
+  describe '#handle_subscription_line_items' do
+    context 'when subscription params are missing' do
+      it 'does not invoke handle_subscription_line_items and does not create a subscription line item' do
+        initial_line_item_count = order.line_items.count
+
+        controller_instance.params = {
+          variant_id: variant.id,
+          subscription_line_item: {}
+        }
+
+        expect(controller_instance.send(:subscription_line_item_params_present?)).to be false
+
+        expect(controller_instance).not_to receive(:handle_subscription_line_items)
+
+        expect(controller_instance).not_to receive(:create_subscription_line_item)
+      end
+    end
+
+    context 'when subscription params are present' do
+      it 'calls create_subscription_line_item with the correct line item' do
+        line_item = create(:line_item, order: order, variant: variant)
+
+        controller_instance.params = {
+          variant_id: variant.id,
+          subscription_line_item: {
+            subscribable_id: 1,
+            quantity: 2,
+            interval_length: 1
+          }
+        }
+
+        allow(order.line_items).to receive(:find_by).with(variant_id: variant.id).and_return(line_item)
+
+        expect(controller_instance).to receive(:create_subscription_line_item).with(line_item)
+
+        controller_instance.send(:handle_subscription_line_items)
+      end
+    end
+  end
+end

--- a/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Spree::Api::LineItemsController, type: :controller do
     subject(:post_create) { post :create, params: params }
 
     let(:params) { line_item_params }
-    let!(:variant) { create :variant }
+    let!(:variant) { create :variant, subscribable: true }
     let!(:order) { create :order }
 
     let(:line_item_params) do
@@ -70,7 +70,7 @@ RSpec.describe Spree::Api::LineItemsController, type: :controller do
     let(:params) { line_item_params }
 
     context 'when adding subscription information' do
-      let(:variant) { create :variant }
+      let(:variant) { create :variant, subscribable: true }
       let(:order) { create :order }
       let(:line_item) { create :line_item, order: order, variant: variant }
       let(:line_item_params) do

--- a/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/spec/controllers/spree/api/orders_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Spree::Api::OrdersController, type: :controller do
   routes { Spree::Core::Engine.routes }
 
   let(:order) { create :order }
-  let(:variant) { create :variant }
+  let(:variant) { create :variant, subscribable: true }
 
   describe 'patch /update' do
     subject(:subscription_line_items) do

--- a/spec/decorators/controllers/solidus_subscriptions/spree/orders_controller/create_subscription_line_items_spec.rb
+++ b/spec/decorators/controllers/solidus_subscriptions/spree/orders_controller/create_subscription_line_items_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SolidusSubscriptions::Spree::OrdersController::CreateSubscription
   describe 'POST /orders/populate' do
     subject(:populate) { post :populate, params: params }
 
-    let!(:variant) { create :variant }
+    let!(:variant) { create :variant, subscribable: true }
     let(:params) { line_item_params }
     let(:line_item_params) do
       {

--- a/spec/jobs/solidus_subscriptions/process_subscription_job_spec.rb
+++ b/spec/jobs/solidus_subscriptions/process_subscription_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SolidusSubscriptions::ProcessSubscriptionJob do
     it 'voids the actionable date of the unfulfilled installments' do
       stub_config(clear_past_installments: true)
       subscription = create(:subscription)
-      unfulfilled_installment =  create(:installment, :failed, subscription: subscription)
+      unfulfilled_installment = create(:installment, :failed, subscription: subscription)
 
       described_class.perform_now(subscription)
 

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -26,4 +26,26 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
       expect(interval.from_now).to eq Date.parse("2016-10-22")
     end
   end
+
+  describe "custom validation" do
+    context "when subscribable is not true" do
+      let(:subscribable) { create(:variant, subscribable: false) }
+      let(:line_item) { build(:subscription_line_item, subscribable: subscribable) }
+
+      it "adds an error to subscribable" do
+        line_item.valid?
+        expect(line_item.errors[:subscribable]).to include("The requested item cannot be subscribed")
+      end
+    end
+
+    context "when subscribable is true" do
+      let(:subscribable) { create(:variant, subscribable: true) }
+      let(:line_item) { build(:subscription_line_item, subscribable: subscribable) }
+
+      it "does not add an error to subscribable" do
+        line_item.valid?
+        expect(line_item.errors[:subscribable]).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Summary:
---
This PR introduces improvements and new features to the Solidus Subscriptions module, with a focus on subscription validation and handling subscription-related logic.

### Changes:
---

#### Validation for Subscribable Products:

- A custom validation `ensure_subscribable_valid` is added to the `SolidusSubscriptions::LineItem` model. This validation ensures that only products marked as subscribable can be added to a subscription. If a product is not subscribable, an error is added to the `subscribable` field with the message "The requested item cannot be subscribed".

#### Localization:

- Added an entry to `config/locales/en.yml` to define the error message for the subscribable validation ("The requested item cannot be subscribed").

#### Subscription Form Enhancements:

- Updated the subscription form in `app/views/cart_line_items/_subscription_fields.html.erb` to display subscription fields dynamically based on whether a product variant is subscribable. The form will show the subscription options only if the selected variant is subscribable.

#### Controller Enhancements:

- Updated the `CreateSubscription` concern to improve the logic for handling subscription line items. A new helper method `valid_subscription_line_item_params?` is introduced to ensure that all required parameters are present before processing subscription-related actions.

#### Promotion Rules Registration:

- Ensured that promotion rules for subscriptions (`SubscriptionCreationOrder` and `SubscriptionInstallmentOrder`) are only registered if the `Spree::Promotion` class is defined, ensuring compatibility with different Solidus versions.

#### Test Coverage:

- Added comprehensive tests to ensure the new validation behavior is functioning correctly.
- The tests include cases for both valid and invalid subscription line items, verifying that the appropriate error messages are triggered when the product is not subscribable.

#### New Tests:

- Added tests for `CreateSubscription` concern, particularly for the new helper method `valid_subscription_line_item_params?`.
- Expanded coverage for the `SolidusSubscriptions::LineItem` model to test the new subscribable validation.
- Updated various existing tests to work with the new subscribable functionality, including those for the API controllers and subscription logic.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
