### PR TITLE
Conditionally version sqlite3 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,9 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3'
+  older_solidus = ['v4.1', 'v4.2', 'v4.3']
+  sqlite_version = older_solidus.include?(branch) ? "~> 1.4" : "~> 2.0"
+  gem 'sqlite3', sqlite_version
 end
 
 gemspec


### PR DESCRIPTION
Older versions of Rails, and thus older versions of Solidus, are incompatible with the `sqlite3` gem 1.x. This makes sure we use the right version for each Solidus version.
