### PR TITLE
Fix flaky subscription spec

### DIFF
--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -1033,6 +1033,12 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
     before { stub_config(maximum_total_skips: 1) }
 
+    around do |example|
+      travel_to(Time.zone.parse("2024-09-15")) do
+        example.run
+      end
+    end
+
     context 'when the successive skips have been exceeded' do
       let(:successive_skips) { 1 }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,4 +27,6 @@ RSpec.configure do |config|
   if Spree.solidus_gem_version < Gem::Version.new('2.11')
     config.extend Spree::TestingSupport::AuthorizationHelpers::Request, type: :system
   end
+
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
This spec is currently failing, because it implicitly depends on there not being February between now and the expected date. Fixing by pretending to be in the past.
